### PR TITLE
REFACTOR-21. Report API/E2E test status back to main repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,9 +101,9 @@ jobs:
     name: Report status back to main repo
     runs-on: ubuntu-latest
     needs: test
+    if: ${{ github.event_name == 'repository_dispatch' }}
     steps:
       - name: Create or update check run in main repo
-        if: github.event_name == 'repository_dispatch'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.PAT_FOR_MAIN_REPO }}


### PR DESCRIPTION
### Summary

Add CI integration between the main repo and the test repo: dispatches test runs on PRs, consolidates caching, and reports results back as a GitHub Check

### Changes

- New triggers: pull_request, manual workflow_dispatch, and repository_dispatch: [run-tests]
- Concurrency: cancels in-flight runs per branch
- Runs report-job after test with a PAT to call github.checks.create()
- Posts a “completed” check with success or failure based on the test result
