### PR TITLE
REFACTOR-22. Fix the integration between test‐repo dispatch & status reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,19 +101,27 @@ jobs:
     name: Report status back to main repo
     runs-on: ubuntu-latest
     needs: test
+
     if: ${{ github.event_name == 'repository_dispatch' }}
+
+    env:
+      PAT: ${{ secrets.PAT_FOR_MAIN_REPO }}
+      TEST_RESULT: ${{ needs.test.result }}
+      HEAD_SHA: ${{ github.event.client_payload.sha }}
+
     steps:
       - name: Create or update check run in main repo
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PAT_FOR_MAIN_REPO }}
+          github-token: ${{ env.PAT }}
           script: |
-            const result = needs.test.result === 'success' ? 'success' : 'failure';
+            const result = process.env.TEST_RESULT;
+            const headSha = context.payload.client_payload.sha;
             await github.checks.create({
               owner: 'darliaro',
               repo: 'LumaireJ',
               name: 'API & E2E Tests',
-              head_sha: '${{ github.event.client_payload.sha }}',
+              head_sha: headSha,
               status: 'completed',
               conclusion: result,
               output: {


### PR DESCRIPTION
### Summary

Fix new workflow Run API & E2E Tests

### Changes

- Exports DATABASE_URL/BASE_URL at the job level
- After tests complete, a second job (report-status) runs only on repository_dispatch, calling actions/github-script with a PAT to create/update a GitHub Check on the main repo with success/failure
