### PR TITLE
[INFRA #35] Fix E2E CI — Playwright cache key mismatch, checks permission, reporter blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  checks: write
 
 concurrency:
   group: api-e2e-tests-${{ github.ref }}
@@ -78,7 +79,7 @@ jobs:
 
       - name: Install Playwright browsers
         working-directory: tests
-        run: pdm run playwright install chromium --with-deps
+        run: pdm run playwright install --with-deps
 
       - name: Setup Java
         uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.6.0
@@ -175,6 +176,7 @@ jobs:
       - name: Publish API Test Results
         uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5 # v1.9.1
         if: always()
+        continue-on-error: true
         with:
           name: API Test Results
           path: tests/junit-results-api.xml
@@ -251,8 +253,8 @@ jobs:
       - name: Restore Playwright browsers cache
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
-          key: playwright-${{ runner.os }}-${{ matrix.browser }}-${{ hashFiles('pdm.lock') }}
-          restore-keys: playwright-${{ runner.os }}-${{ matrix.browser }}-
+          key: playwright-${{ runner.os }}-${{ hashFiles('pdm.lock') }}
+          restore-keys: playwright-${{ runner.os }}-
           path: |
             ~/.cache/ms-playwright
 
@@ -290,6 +292,7 @@ jobs:
       - name: Publish E2E Test Results
         uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5 # v1.9.1
         if: always()
+        continue-on-error: true
         with:
           name: E2E Test Results (${{ matrix.browser }})
           path: tests/junit-results-e2e-${{ matrix.browser }}.xml


### PR DESCRIPTION
## Summary
- Fix Playwright browser cache key mismatch: `setup` wrote key without browser name; `test-e2e` restored with browser-specific key — always a cache miss
- `setup` only installed `chromium`; changed to `playwright install --with-deps` to pre-cache all three browsers (chromium, firefox, webkit)
- Add `checks: write` permission so `dorny/test-reporter` can post check run results (was failing with `Resource not accessible by integration`)
- Add `continue-on-error: true` to both Publish steps — a reporter failure should never block E2E via `needs: [setup, test-api]`

## Test Report

| Metric      | Count |
|-------------|-------|
| Total Tests | 6     |
| Passed      | 4     |
| Failed      | 0     |
| Skipped     | 2     |

### Tests Added / Modified
No test files changed — CI workflow only.

## Test Plan
- [x] Linting passes (`pdm run lint`)
- [x] API tests pass locally (4 passed, 2 skipped pre-existing)
- [x] E2E errors are pre-existing local env issue (`playwright install` needed locally)
- [ ] CI run validates E2E executes end-to-end in GitHub Actions

Closes #35