### PR TITLE
[TEST #41] Extend API coverage: GET, LIST, DELETE journal

### DIFF
--- a/tests/api/clients/api_client.py
+++ b/tests/api/clients/api_client.py
@@ -52,6 +52,54 @@ class APIClient:
 
         return response.status_code, body
 
+    def get_journal_entry(self, entry_id: str) -> tuple[int, dict[str, Any]]:
+        """Fetch a single journal entry by ID.
+
+        Returns:
+            tuple: (status_code, response_body)
+
+        Raises:
+            requests.exceptions.HTTPError: On non-2xx response.
+            requests.exceptions.RequestException: On connection/timeout errors.
+            ValueError: On non-JSON response body.
+        """
+        response = self._request("GET", f"/journal/{entry_id}")
+        response.raise_for_status()
+
+        try:
+            body = response.json()
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"Non-JSON response from GET /journal/{entry_id} (status {response.status_code}): "
+                f"{response.text[:200]}"
+            ) from exc
+
+        return response.status_code, body
+
+    def list_journal_entries(self) -> tuple[int, list[dict[str, Any]]]:
+        """Fetch all journal entries.
+
+        Returns:
+            tuple: (status_code, list of response bodies)
+
+        Raises:
+            requests.exceptions.HTTPError: On non-2xx response.
+            requests.exceptions.RequestException: On connection/timeout errors.
+            ValueError: On non-JSON response body.
+        """
+        response = self._request("GET", "/journal")
+        response.raise_for_status()
+
+        try:
+            body = response.json()
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"Non-JSON response from GET /journal (status {response.status_code}): "
+                f"{response.text[:200]}"
+            ) from exc
+
+        return response.status_code, body
+
     def delete_journal_entry(self, entry_id: str) -> int:
         """Delete a journal entry by ID.
 

--- a/tests/api/test_journal.py
+++ b/tests/api/test_journal.py
@@ -187,6 +187,9 @@ def test_list_journal_entries_includes_created_entry(
     ids = [e["id"] for e in entries]
     assert created_id in ids, f"Created entry {created_id} not found in list: {ids}"
 
+    matched = next(e for e in entries if e["id"] == created_id)
+    JournalEntryResponse.model_validate(matched)
+
 
 @pytest.mark.api
 @pytest.mark.journal

--- a/tests/api/test_journal.py
+++ b/tests/api/test_journal.py
@@ -26,7 +26,11 @@ def journal_entry_factory(api_client: APIClient) -> Generator[_CreateFn]:
     yield _create
 
     for entry_id in created_ids:
-        api_client.delete_journal_entry(entry_id)
+        try:
+            api_client.delete_journal_entry(entry_id)
+        except requests.exceptions.HTTPError as exc:
+            if exc.response.status_code != 404:
+                raise
 
 
 @pytest.mark.api
@@ -121,3 +125,101 @@ def test_create_journal_entry_with_special_characters_succeeds(
     assert status_code == 201
     entry = JournalEntryResponse.model_validate(result)
     assert entry.content == special_content
+
+
+@pytest.mark.api
+@pytest.mark.journal
+@pytest.mark.smoke
+def test_get_journal_entry_returns_created_entry(
+    journal_entry_factory: _CreateFn,
+    api_client: APIClient,
+    journal_entry_data: JournalEntryData,
+) -> None:
+    """Test that GET /journal/{id} returns the entry that was created."""
+    _, created = journal_entry_factory(journal_entry_data.content, journal_entry_data.mood)
+    entry_id = str(created["id"])
+
+    status_code, result = api_client.get_journal_entry(entry_id)
+
+    assert status_code == 200
+    entry = JournalEntryResponse.model_validate(result)
+    assert entry.id == created["id"]
+    assert entry.content == journal_entry_data.content
+    assert entry.mood == journal_entry_data.mood
+
+
+@pytest.mark.api
+@pytest.mark.journal
+@pytest.mark.regression
+def test_get_journal_entry_missing_returns_404(api_client: APIClient) -> None:
+    """Test that GET /journal/{id} for a non-existent ID returns 404."""
+    with pytest.raises(requests.exceptions.HTTPError) as exc_info:
+        api_client.get_journal_entry("0")
+
+    assert exc_info.value.response.status_code == 404
+
+
+@pytest.mark.api
+@pytest.mark.journal
+@pytest.mark.smoke
+def test_list_journal_entries_returns_list(api_client: APIClient) -> None:
+    """Test that GET /journal returns a JSON array."""
+    status_code, result = api_client.list_journal_entries()
+
+    assert status_code == 200
+    assert isinstance(result, list)
+
+
+@pytest.mark.api
+@pytest.mark.journal
+@pytest.mark.regression
+def test_list_journal_entries_includes_created_entry(
+    journal_entry_factory: _CreateFn,
+    api_client: APIClient,
+    journal_entry_data: JournalEntryData,
+) -> None:
+    """Test that a newly created entry appears in the list response."""
+    _, created = journal_entry_factory(journal_entry_data.content)
+    created_id = created["id"]
+
+    _, entries = api_client.list_journal_entries()
+
+    ids = [e["id"] for e in entries]
+    assert created_id in ids, f"Created entry {created_id} not found in list: {ids}"
+
+
+@pytest.mark.api
+@pytest.mark.journal
+@pytest.mark.smoke
+def test_delete_journal_entry_returns_no_content(
+    journal_entry_factory: _CreateFn,
+    api_client: APIClient,
+    journal_entry_data: JournalEntryData,
+) -> None:
+    """Test that DELETE /journal/{id} returns 204 No Content."""
+    _, created = journal_entry_factory(journal_entry_data.content)
+    entry_id = str(created["id"])
+
+    status_code = api_client.delete_journal_entry(entry_id)
+
+    assert status_code == 204
+
+
+@pytest.mark.api
+@pytest.mark.journal
+@pytest.mark.regression
+def test_delete_journal_entry_removes_entry(
+    journal_entry_factory: _CreateFn,
+    api_client: APIClient,
+    journal_entry_data: JournalEntryData,
+) -> None:
+    """Test that a deleted entry is no longer accessible via GET."""
+    _, created = journal_entry_factory(journal_entry_data.content)
+    entry_id = str(created["id"])
+
+    api_client.delete_journal_entry(entry_id)
+
+    with pytest.raises(requests.exceptions.HTTPError) as exc_info:
+        api_client.get_journal_entry(entry_id)
+
+    assert exc_info.value.response.status_code == 404


### PR DESCRIPTION
## Summary

- Add `get_journal_entry()` and `list_journal_entries()` to `APIClient`
- Fix `journal_entry_factory` teardown to tolerate 404 (DELETE tests clean up mid-test, making teardown idempotent)
- Add 6 new tests covering GET single (200), GET missing (404), LIST structure, LIST includes created entry, DELETE 204, DELETE removes entry

## Test Report

| Metric      | Count |
|-------------|-------|
| Total Tests | 14    |
| Passed      | 14    |
| Failed      | 0     |
| Skipped     | 0     |

### Tests Added / Modified
- `test_get_journal_entry_returns_created_entry` (smoke)
- `test_get_journal_entry_missing_returns_404` (regression)
- `test_list_journal_entries_returns_list` (smoke)
- `test_list_journal_entries_includes_created_entry` (regression)
- `test_delete_journal_entry_returns_no_content` (smoke)
- `test_delete_journal_entry_removes_entry` (regression)

## Test Plan
- [x] All tests pass locally (`pdm run pytest`)
- [x] Linting passes (`pdm run lint`)
- [x] New tests have appropriate markers
- [x] Fixtures properly scoped

Closes #41